### PR TITLE
fixing a holdover from LOTlib2 and a typo in the tutorial

### DIFF
--- a/Documentation/Tutorial.md
+++ b/Documentation/Tutorial.md
@@ -120,7 +120,7 @@ For convenience, when `compute_posterior` is called, it sets attributes on `h` f
 
 We are almost there. We have define a grammar and a hypothesis which uses the grammar to define a prior, and custom code to define a likelihood. LOTlib3's main claim to fame is that we can simply import MCMC routines and do inference over the space defined by the grammar. It's very easy:
 ```python
-    from LOTlib3.Inference.Samplers.MetropolisHastings import MetropolisHastingsSampler
+    from LOTlib3.Samplers.MetropolisHastings import MetropolisHastingsSampler
     
     # define a "starting hypothesis". This one is essentially copied by 
     # all proposers, so the sampler doesn't need to know its type or anything. 
@@ -157,7 +157,7 @@ Fortunately, we can hack our hypothesis class to address this by catching the ex
 
     class MyHypothesis(LOTHypothesis):
         def __init__(self, **kwargs):
-            LOTHypothesis.__init__(self, grammar=grammar, display="lambda: %s", **kwargs)
+            LOTHypothesis.__init__(self, grammar=grammar, display="lambda x: %s", **kwargs)
             
         def __call__(self, *args):
             try:

--- a/Documentation/Tutorial.md
+++ b/Documentation/Tutorial.md
@@ -49,8 +49,8 @@ renders into the program "hello" but
 renders into "hello()". 
 
 
-The production probabilities are, for now, fixed. Note that the numbers have probabilities proportional to 1/n**2. But overall, these also have a multiplier of 10, making them as a group much more likely than other operations. This is important because the PCFG has to define a proper probability distribution. This means that a nonterminal must have a probability of 1 of eventually leading to a terminal (a terminal is any rule with `None` as its <ARGUMENTS>). The easiest way to ensure this is to upweight the probabilities on terminals like the numbers here. 
-
+The production probabilities are, for now, fixed. Note that the numbers have probabilities proportional to 1/n**2. But we multiplied those values by 10, making them as a group much more likely than other operations. This is important because the PCFG has to define a proper probability distribution. This means that a nonterminal must have a probability of 1 of eventually leading to a terminal (a terminal is any rule with `None` as its <ARGUMENTS>). The easiest way to ensure this is to upweight the probabilities on terminals so they are more likely to be sampled.
+    
 We can see some productions from this grammar if we call Grammar.generate. We will also show the probability of this tree according to the grammar, which is computed by renormalizing the <PROBABILITY> values of each rule when expanding each nonterminal:
 ```python
     for _ in xrange(100):
@@ -59,7 +59,7 @@ We can see some productions from this grammar if we call Grammar.generate. We wi
 ```
 As you can see, the longer/bigger trees have lower (more negative) probabilities, implementing essentially a simplicity bias. These PCFG probabilities will often be our prior for Bayesian inference. 
 
-Note that even though each `t` is a tree (a hierarchy of LOTlib3.FunctionNodes), it renders nicely above as a string. This is defaultly how to expressions are evaluated in python. But we can see more of the internal structure using `t.fullprint()`, which shows the nonterminals, functions, and arguments at each level:
+Note that even though each `t` is a tree (a hierarchy of LOTlib3.FunctionNodes), it renders nicely above as a string. This is defaultly how expressions are evaluated in python. But we can see more of the internal structure using `t.fullprint()`, which shows the nonterminals, functions, and arguments at each level:
 ```python
     t = grammar.generate()
     t.fullprint()
@@ -85,9 +85,9 @@ Fortunately, for our purposes, there is a simple hypothesis class that it built-
                 return log((1.0-datum.alpha)/100.)
             
 ```
-There are a few things going on here. First, we import LOTHypothesis and use that to define the new class `MyHypothesis`. LOTHypothesis defines `compute_prior()` and `compute_likelihood(data)`--more about these later. We define the initializer `__init__`. We overwrite the LOTHypothesis default and specify that the grammar we want is the one defined above. LOTHypotheses also defaultly take an argument called `x` (more on this later), but for now we want our hypothesis to be a function of no arguments. When we convert the value of the hypothesis into a string, it will get substituted into the `display` keyword. Here, `display="lambda: %s` meaning that the hypothesis will be displayed and also evaled in python as appearing after a lambda.
+There are a few things going on here. First, we import LOTHypothesis and use that to define the new class `MyHypothesis`. LOTHypothesis defines `compute_prior()` and `compute_likelihood(data)`--more about these later. We define the initializer `__init__`. We overwrite the LOTHypothesis default and specify that the grammar we want is the one defined above. LOTHypotheses also defaultly take an argument called `x` (more on this later), but for now we want our hypothesis to be a function of no arguments. When we convert the value of the hypothesis into a string, it will get substituted into the `display` keyword. Here, `display="lambda: %s"` meaning that the hypothesis will be displayed and also evaled in python as appearing after a lambda.
 
-Essentially, `compute_likelihood` maps `compute_single_likelihood` over a list of data (treating each as IID conditioned on the hypothesis). So when we want to define how the likelihood works, we typically want to overwrite `compute_single_likelihood` as we have above. In this function, we expect an input `datum` with attirbutes `input`, `output`, and `alpha`. The LOTHypothesis `self` can be viewed as a function (here, one with no arguments) and so it can be called on `datum.input`. The likelihood this defines is one in which we generate a random number from 1..100 with probability `1-datum.alpha` and the correct number with probability `datum.alpha`. Thus, when the hypothesis returns the correct value (e.g. `self(*datum.input) == datum.output`) we must add these quantities to get the total probability of producing the data. When it does not, we must return only the former. LOTlib3.Hypotheses.Likelihoods defines a number of other standard likelihoods, including the most commonly used  one, `BinaryLikelihood`. 
+Essentially, `compute_likelihood` maps `compute_single_likelihood` over a list of data (treating each as IID conditioned on the hypothesis). So when we want to define how the likelihood works, we typically want to overwrite `compute_single_likelihood` as we have above. In this function, we expect an input `datum` with attributes `input`, `output`, and `alpha`. The LOTHypothesis `self` can be viewed as a function (here, one with no arguments) and so it can be called on `datum.input`. The likelihood this defines is one in which we generate a random number from 1..100 with probability `1-datum.alpha` and the correct number with probability `datum.alpha`. Thus, when the hypothesis returns the correct value (e.g. `self(*datum.input) == datum.output`) we must add these quantities to get the total probability of producing the data. When it does not, we must return only the former. LOTlib3.Hypotheses.Likelihoods defines a number of other standard likelihoods, including the most commonly used  one, `BinaryLikelihood`. 
 
 ## Data
 
@@ -96,7 +96,7 @@ Given that our hypothesis wants those kinds of data, we can then create data as 
     from LOTlib3.DataAndObjects import FunctionData
     data = [ FunctionData(input=[6], output=12, alpha=0.95) ]
 ```
-Note here that the most natural form of data is a list--even if its only a single element--where each element, a datum, gets passed to `compute_single_likelihood`. The data here specifies the input, output, and noise value `alpha`. Note that even though `alpha` could live as an attribute of hypotheses, it makes most sense to view it as a known part of the data. 
+Note here that the most natural form of data is a list--even if it is only a single element--where each element, a datum, gets passed to `compute_single_likelihood`. The data here specifies the input, output, and noise value `alpha`. Note that even though `alpha` could live as an attribute of hypotheses, it makes most sense to view it as a known part of the data. 
 
 ## Making hypotheses
 
@@ -535,7 +535,7 @@ For instance, this code might generate the following expression, which is obscur
 ```python
     ((lambda F1: F1(x+1))(lambda y1: y1+3))
 ```
-Here, we have define a variable `F1` that really represents the *function* `lambda y1: y1+3`. The value that is returned is the value of applying `F1` to the overall hypothesis value `x` plus `1`. Note that LOTlib3 here has correctly used `F1` in a context where an EXPR is needed (due to `bv_type='EXPR'` on `FUNCDEF`). It knows that the argument to `F1` is also an EXPR, which here happens to be expanded to `x+1`. It also knows that `F1` is itself a function, and it binds this function (through the outermost apply) to `lambda y1: y1+3`. LOTlib3 knows that `F1` can only be used in the left hand side of this appyl, and `y1` can only be used on the right. This holds even if multiple bound variables of different types are generated. 
+Here, we have define a variable `F1` that really represents the *function* `lambda y1: y1+3`. The value that is returned is the value of applying `F1` to the overall hypothesis value `x` plus `1`. Note that LOTlib3 here has correctly used `F1` in a context where an EXPR is needed (due to `bv_type='EXPR'` on `FUNCDEF`). It knows that the argument to `F1` is also an EXPR, which here happens to be expanded to `x+1`. It also knows that `F1` is itself a function, and it binds this function (through the outermost apply) to `lambda y1: y1+3`. LOTlib3 knows that `F1` can only be used in the left hand side of this apply, and `y1` can only be used on the right. This holds even if multiple bound variables of different types are generated. 
 
 This ability to define functions provides some of the most interesting learning dynamics for the model. A nice example is provided in LOTlib3.Examples.Magnetism, where learners take data and learn predicates classifying observable objects into two kinds, as well as laws stated over those kinds.
 


### PR DESCRIPTION
- Inference sub-module does not seem to exist in LOTLib3
- the example lambda function is missing the needed argument from the earlier example